### PR TITLE
Remove lightdm gtk greeter settings script as we use slick-greeter now

### DIFF
--- a/katsu/modules/flagship/flagship-extra.sh
+++ b/katsu/modules/flagship/flagship-extra.sh
@@ -9,4 +9,4 @@
 # but we want to theme it anyway, so we'll just copy the file to the correct location
 
 # If any of the GTK greeter devs are reading this, please add a way to load drop-in files! :3
-cp -v /etc/lightdm/lightdm.conf.d/50-ultramarine-flagship-lightdm-gtk-greeter.conf /etc/lightdm/lightdm-gtk-greeter.conf
+# cp -v /etc/lightdm/lightdm.conf.d/50-ultramarine-flagship-lightdm-gtk-greeter.conf /etc/lightdm/lightdm-gtk-greeter.conf


### PR DESCRIPTION
The build no longer works because slick-greeter is now installed by default instead of lightdm-gtk-greeter