### PR TITLE
Further improve the QEMU scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 katsu-work/
 .DS_Store
 *.env*
+.test/


### PR DESCRIPTION
This is a continuation of #50, further adding more features in the script such as an ephemeral disk image for testing installs, a wipe option to clean up all katsu artifacts and a cleanup script to clean up after katsu failures.