### PR TITLE
remove explicit dracut-config-generic from builds

### DIFF
--- a/katsu/modules/base/base-disk.yaml
+++ b/katsu/modules/base/base-disk.yaml
@@ -30,7 +30,6 @@ dnf:
     - kernel
     - glibc
     - glibc-common
-    - dracut-config-generic
     - dracut-tools
     - dnf
     - dracut

--- a/katsu/modules/base/base.yaml
+++ b/katsu/modules/base/base.yaml
@@ -65,7 +65,6 @@ dnf:
 #     - kernel-core
 #     - glibc
 #     - glibc-common
-#     - dracut-config-generic
 #     - dracut-tools
 #     - dnf
 #     - dracut

--- a/katsu/modules/live/live.yaml
+++ b/katsu/modules/live/live.yaml
@@ -16,9 +16,7 @@ dnf:
     - deepin-wallpapers
   packages:
     - glibc-all-langpacks
-    - dracut-config-generic
     - dracut-live
-    - dracut-config-generic
     - dracut-network
     - dracut-squash
     - libblockdev-nvdimm


### PR DESCRIPTION
Back when we wrote this, I had no idea what this package even actually does, but now that we know this is actually unwanted and is the root cause of initramfs inflation