### PR TITLE
move surface images to use upstream surface-dtx-daemon package

### DIFF
--- a/katsu/modules/ports/surface/surface.yaml
+++ b/katsu/modules/ports/surface/surface.yaml
@@ -13,7 +13,7 @@ dnf:
     - iptsd
     - libwacom-surface
     - ultramarine-release-surface
-    - terra-surface-dtx-daemon
+    - surface-dtx-daemon
     # Below for camera support
     - intel-vsc-firmware
     - libcamera


### PR DESCRIPTION
The reason for the downstream package has been fixed upstream.