### PR TITLE
fix(WSL): update mesa-libxatracker package

### DIFF
--- a/katsu/modules/ports/wsl/wsl.yaml
+++ b/katsu/modules/ports/wsl/wsl.yaml
@@ -41,7 +41,7 @@ dnf:
     - fedora-repos
     - ultramarine-langpacks-en
     - mesa-libGLU
-    - mesa-libxatracker
+    - mesa-compat-libxatracker
     - mesa-vulkan-drivers
     - mesa-filesystem
     - mesa-libgbm


### PR DESCRIPTION
This package was removed in Mesa 43 Fedora package

https://bugzilla.redhat.com/show_bug.cgi?id=2396015

https://lists.openembedded.org/g/openembedded-core/topic/patch_1_2_mesa_remove_xa/113335722