### PR TITLE
chore: cleanup/use @ultramarine-product-common

### DIFF
--- a/katsu/modules/base/base.yaml
+++ b/katsu/modules/base/base.yaml
@@ -67,3 +67,4 @@ dnf:
     - ultramarine-release
     - ultramarine-repos
     - ultramarine-logos
+    - "@ultramarine-product-common"

--- a/katsu/modules/live/live.yaml
+++ b/katsu/modules/live/live.yaml
@@ -36,15 +36,9 @@ dnf:
     - gjs
     - util-linux-user
     - livesys-scripts
-    - rsync
-    - htop
-    - vim
-    - nano
     # for drivers and other stuff
     - kernel
     - kernel-devel-matched
     # UMSS
-    - um
-    - dive
     - mkfstab
     - dracut-strip-trigger

--- a/katsu/modules/ports/wsl/wsl.yaml
+++ b/katsu/modules/ports/wsl/wsl.yaml
@@ -32,8 +32,6 @@ dnf:
     - glibc
     - glibc-common
     - dnf
-    - git
-    - vim
     - rpm
     - libgomp
     - ultramarine-release-identity-basic


### PR DESCRIPTION
- Add @ultramarine-product-common to base.yml, as base.yml is pulled in to everything (except WSL)
- Remove packages in various files that already/now exist in @ultramarine-product-common

REQUIRES https://github.com/Ultramarine-Linux/packages/pull/280 to be merged and comps update pushed